### PR TITLE
Improve suffocation criteria

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -94,10 +94,18 @@ minetest.register_globalstep(function(dtime)
 		player:set_physics_override(def.speed, def.jump, def.gravity)
 		--print ("Speed:", def.speed, "Jump:", def.jump, "Gravity:", def.gravity)
 
-		-- is player suffocating inside node? (only solid "normal" type nodes)
-		if minetest.registered_nodes[ playerplus[name].nod_head ].walkable
-		and minetest.registered_nodes[ playerplus[name].nod_head ].drawtype == "normal"
-		and not minetest.check_player_privs(name, {noclip = true}) then
+		-- Is player suffocating inside node? (Only for solid full cube type nodes without damage
+		-- and without group disable_suffocation=1.)
+		local ndef = minetest.registered_nodes[playerplus[name].nod_head]
+
+		if (ndef.walkable == nil or ndef.walkable == true)
+		and (ndef.drowning == nil or ndef.drowning == 0)
+		and (ndef.damage_per_second == nil or ndef.damage_per_second <= 0)
+		and (ndef.collision_box == nil or ndef.collision_box.type == "regular")
+		and (ndef.node_box == nil or ndef.node_box.type == "regular")
+		and (ndef.groups.disable_suffocation ~= 1)
+		-- Check privilege, too
+		and (not minetest.check_player_privs(name, {noclip = true})) then
 
 			if player:get_hp() > 0 then
 				player:set_hp(player:get_hp() - 2)


### PR DESCRIPTION
The suffocation of this mod is kinda broken IMO because the criteria for suffocation were too loose. For instance, suffocation applies when you are near high fences. Suffocation seems to fail to rule out some cases where suffocation is not desired.

The new check is basically the same as in my `real_suffocation` mod. The new check is based on physical properties alone, visual properties are ignored. Also, the group `disable_suffocation=1` is checked.
The new check automatically rules out nodes like fences.

Rationale from `real_suffocation`:
```
Here's what it checks and why:
- Walkable: Must be walkable, which means player can get stuck inside. If player can move freely, suffocation does not make sense
- Drowning and damage: If node has set any of those explicitly, it probably knows why. We don't want to mess with it.
- collision_box, node_box: Checks whether we deal with full-sized standard cubes, since only care about those. Everything else is probably too small for suffocation to seem real.
- disable_suffocation group: If set to 1, we bail out. This makes it possible for nodes to defend themselves against hacking. :-)
```